### PR TITLE
Solve the compilation problem in DX Berlin

### DIFF
--- a/src/core/Boss.Modules.PackageProcessor.pas
+++ b/src/core/Boss.Modules.PackageProcessor.pas
@@ -22,7 +22,7 @@ type
 
     procedure LoadTools(AProjectPath: string);
     procedure MakeLink(AProjectPath, AEnv: string);
-    procedure DoLoadBpls(ABpls: TArray<string>);
+    procedure DoLoadBpls(ABpls: TStringDynArray);
 
     constructor Create;
   public
@@ -149,7 +149,9 @@ var
   LOrderFileName: string;
   LOrder: TStringList;
   LIndex: Integer;
+  I: Integer;
 begin
+  Result := Nil;
   if not DirectoryExists(GetEnv(C_ENV_BPL)) then
     Exit();
 
@@ -163,7 +165,9 @@ begin
       for LIndex := 0 to LOrder.Count - 1 do
         LOrder.Strings[LIndex] := GetEnv(C_ENV_BPL) + TPath.DirectorySeparatorChar + LOrder.Strings[LIndex];
 
-      Result := LOrder.ToStringArray;
+      SetLength(Result, LOrder.Count);
+      for I := 0 to LOrder.Count - 1 do
+        Result[I] := LOrder[I];
     finally
       LOrder.Free;
     end;
@@ -198,7 +202,7 @@ begin
   DoLoadBpls(LBpls);
 end;
 
-procedure TBossPackageProcessor.DoLoadBpls(ABpls: TArray<string>);
+procedure TBossPackageProcessor.DoLoadBpls(ABpls: TStringDynArray);
 var
   LBpl: string;
   LFlag: Integer;


### PR DESCRIPTION
 **- Problem**
```
	"<user>\.boss\modules\5a7f3942105f389501dd9b6feb076eff\modules\boss-ide\boss_ide.dproj" (Build target) (1) ->
(_PasCoreCompile target) ->
  src\core\Boss.Modules.PackageProcessor.pas(166): error E2010: Incompatible types: 'TStringDynArray' and 'System.TArray<System.string>'
  src\core\Boss.Modules.PackageProcessor.pas(198): error E2010: Incompatible types: 'System.TArray<System.string>' and 'TStringDynArray'
  src\core\Boss.Modules.PackageProcessor.pas(245): error E2010: Incompatible types: 'System.TArray<System.string>' and 'TStringDynArray'
  boss_ide.dpk(38): error F2063: Could not compile used unit 'Boss.Modules.PackageProcessor.pas'

    1 Warning(s)
    4 Error(s)

Time Elapsed 00:00:01.24
```

 **- Solution**
	Replace 'System.TArray <System.string>' with 'TStringDynArray'